### PR TITLE
Include bootstrap-sprockets

### DIFF
--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -1,4 +1,5 @@
 // import the CSS framework
+@import "bootstrap-sprockets";
 @import "bootstrap";
 
 // make all images responsive by default


### PR DESCRIPTION
Required since 3.2.0, https://github.com/twbs/bootstrap-sass/releases/tag/v3.2.0.
